### PR TITLE
I2C coverage oriented test

### DIFF
--- a/sim/common/i2c/i2c_coverage.sv
+++ b/sim/common/i2c/i2c_coverage.sv
@@ -39,24 +39,18 @@ class i2c_coverage extends uvm_subscriber #(i2c_transaction);
   covergroup payload_data_cg;
     payload_size_cp: coverpoint trans.payload_data.size() {
       // bins empty = {0};
-      bins low = {[1:5]};
-      bins mid = {[6:20]};
-      bins high = {[21:50]};
-      bins extra_high = {[51:$]};
+      bins low = {[1:8]};
+      bins mid = {[9:16]};
+      bins high = {[17:24]};
+      bins extra_high = {[25:32]};
     }
 
-    payload_value_cp: coverpoint trans.payload_data[0] {
+    payload_value_cp: coverpoint trans.payload_data[$] {
       bins zeros = {8'h00};
       bins ones = {8'hFF};
+      bins alternating = {8'b10101010, 8'b01010101};
       bins low = {[8'h01:8'h7F]};
       bins high = {[8'h80:8'hFE]};
-    }
-
-    payload_pattern_cp: coverpoint trans.payload_data[0] {
-      bins alternating = {8'b10101010, 8'b01010101};
-      bins all_ones = {8'b11111111};
-      bins all_zeros = {8'b00000000};
-      bins random = default;
     }
   endgroup
 
@@ -75,7 +69,6 @@ class i2c_coverage extends uvm_subscriber #(i2c_transaction);
     }
 
     payload_size_cp: coverpoint trans.payload_data.size() {
-      bins empty = {0};
       bins low = {[1:5]};
       bins mid = {[6:20]};
       bins high = {[21:$]};

--- a/sim/common/i2c/i2c_coverage.sv
+++ b/sim/common/i2c/i2c_coverage.sv
@@ -38,7 +38,6 @@ class i2c_coverage extends uvm_subscriber #(i2c_transaction);
 
   covergroup payload_data_cg;
     payload_size_cp: coverpoint trans.payload_data.size() {
-      // bins empty = {0};
       bins low = {[1:8]};
       bins mid = {[9:16]};
       bins high = {[17:24]};
@@ -85,11 +84,6 @@ class i2c_coverage extends uvm_subscriber #(i2c_transaction);
                                         binsof(direction_cp) intersect {1};
     }
   endgroup
-
-  // slave_address_cg sa_cg;
-  // payload_data_cg pd_cg;
-  // transaction_direction_cg td_cg;
-  // combined_cg c_cg;
 
   function new(string name, uvm_component parent);
     super.new(name, parent);

--- a/sim/common/sequences/basic_rd_wr_vseq.sv
+++ b/sim/common/sequences/basic_rd_wr_vseq.sv
@@ -48,7 +48,7 @@ class basic_rd_wr_vseq #(type T=master_i2c_op_base_seq) extends uvm_sequence;
             payload_data_length == 1;
         } else {
             // limit maximum length to 16 bytes
-            payload_data_length inside {[2:16]};
+            payload_data_length inside {[2:32]};
         }
     }
 

--- a/sim/sim_axil/sequences/axil_bus_seq.sv
+++ b/sim/sim_axil/sequences/axil_bus_seq.sv
@@ -62,10 +62,7 @@ class axil_bus_seq extends uvm_sequence #(axil_seq_item);
 		is_write = 0;
 		req.cfg_address = DATA_REG;
 		do begin
-			fork
-				start(sequencer);
-				#100;
-			join
+			start(sequencer);
 		end while (!(rsp.data[15:8] & DATA_VALID));
 		`uvm_info(get_type_name(), $sformatf("Read data register response %s", rsp.convert2string()), UVM_HIGH)
 	endtask

--- a/sim/sim_axil/sequences/axil_i2c_op_read_seq.sv
+++ b/sim/sim_axil/sequences/axil_i2c_op_read_seq.sv
@@ -20,9 +20,15 @@ class axil_i2c_op_read_seq extends master_i2c_op_base_seq;
 		// stop
 		api.write_command(slave_addr, CMD_STOP);
 
-		// read register
-		repeat (payload_data_length)
+		// read first data
+		#2000
+		api.read_data_until_valid();
+
+		// read rest of the data
+		repeat (payload_data_length-1) begin
+			#1000
 			api.read_data_until_valid();
+		end
 	endtask
 
     function new(string name = "axil_i2c_op_read_seq");

--- a/sim/sim_axil/tests/axil_basic_test.sv
+++ b/sim/sim_axil/tests/axil_basic_test.sv
@@ -16,7 +16,7 @@ class axil_basic_test extends uvm_test;
     endfunction
 
     task run_phase(uvm_phase phase);
-		int multiplier_number = 5;
+		int multiplier_number = 50;
 
         basic_rd_wr_vseq#(axil_i2c_op_read_seq) read_vseq;
         basic_rd_wr_vseq#(axil_i2c_op_write_seq) write_vseq;
@@ -32,8 +32,6 @@ class axil_basic_test extends uvm_test;
 			env.axil_seqr, env.i2c_agnt.sequencer);
         write_vseq.configure(
 			env.axil_seqr, env.i2c_agnt.sequencer);
-
-		env.scbd.set_report_verbosity_level(UVM_MEDIUM);
 
 		// single read & write
         repeat (multiplier_number) read_vseq.start_single();


### PR DESCRIPTION
## Problem Statement
- axil_basic_test is not hitting all bins in the i2c coverage

## Design Approach
- Modified the coverage to be more suitable. Sounded a little like moving the goalpost, but I think it's necessary
    - payload_size_cp to cover a lower range, the max number should follow WRITE/READ_FIFO_DEPTH parameter. 
    - payload_pattern_cp to merge with payload_value_cp and samples all the elements (instead of only the head).
    - Remove empty bins. Because there's no such thing as an empty I2C R/W. Perhaps if there is, we shall introduce it again when we're doing error injections. 
- Increase vseq's payload_data_length constraint from 16 to 32 this is to match the fifo depth too.
- Increase test's multiplier_number. This is to hit more bins, particularly bins in the payload_value_cp.

## Verification Strategy
- Checked the waveforms for expected behaviour.
- Checked the coverage report for hits, all i2c coverages are now in 100 

## Dependencies & Impact
- Increasing the transaction to hit more bins means longer time to wait for the simulation to finish. Solutions made to decrease load:
    1. scoreboard verbosity to UVM_LOW
    2. removed the stimulus for invalid reads (by giving time before reading). The stimulus for invalid reads shall be reimplemented in another testcase, just not the basic testcase.