### PR TITLE
I2C Coverage Byte Sampling

### DIFF
--- a/sim/sim_axil/tests/axil_basic_test.sv
+++ b/sim/sim_axil/tests/axil_basic_test.sv
@@ -16,7 +16,7 @@ class axil_basic_test extends uvm_test;
     endfunction
 
     task run_phase(uvm_phase phase);
-		int multiplier_number = 50;
+		int multiplier_number = 20;
 
         basic_rd_wr_vseq#(axil_i2c_op_read_seq) read_vseq;
         basic_rd_wr_vseq#(axil_i2c_op_write_seq) write_vseq;


### PR DESCRIPTION
## Problem Statement
- Turns out the I2C coverage still doesn't sample each byte (I think only the last one?)
- As a result, to hit the bins, it will need so many transactions (100 i2c trans to barely hit them)

## Design Approach
- Use a foreach loop to sample

## Verification Strategy
- Checked coverage report, counted the total hits of value_cp, should be way more than total I2C transaction

## Dependencies & Impact
- Less amount of repetition required in the test. Yay!